### PR TITLE
Setup observability tools

### DIFF
--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -25,6 +25,7 @@ jobs:
         run: |
           helm repo add prometheus https://prometheus-community.github.io/helm-charts
           helm repo add jaegertracing https://jaegertracing.github.io/helm-charts
+          helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
 
       - name: Lint
         run: >

--- a/charts/data-gateway/Chart.lock
+++ b/charts/data-gateway/Chart.lock
@@ -5,5 +5,8 @@ dependencies:
 - name: jaeger
   repository: https://jaegertracing.github.io/helm-charts
   version: 2.0.0
-digest: sha256:350282c3114464a73c0ded6e66072f7530e4bce8298d90cb73dd19119fc9a123
-generated: "2024-03-14T10:53:42.342035905Z"
+- name: opentelemetry-collector
+  repository: https://open-telemetry.github.io/opentelemetry-helm-charts
+  version: 0.83.0
+digest: sha256:c64dbb83ab863fb6f4c83dd8fc4505508072fda7b83f3ae1d1ac96af4b3b0c5f
+generated: "2024-03-14T11:22:20.559143777Z"

--- a/charts/data-gateway/Chart.yaml
+++ b/charts/data-gateway/Chart.yaml
@@ -14,3 +14,7 @@ dependencies:
     repository: https://jaegertracing.github.io/helm-charts
     version: 2.0.0
     condition: jaeger.enabled
+  - name: opentelemetry-collector
+    repository: https://open-telemetry.github.io/opentelemetry-helm-charts
+    version: 0.83.0
+    condition: opentelemetry-collector.enabled

--- a/charts/data-gateway/values.yaml
+++ b/charts/data-gateway/values.yaml
@@ -37,7 +37,7 @@ prometheus:
           static_configs:
             - targets:
                 - localhost:9090
-        - job_name: "kubernetes-service-endpoints"
+        - job_name: kubernetes-service-endpoints
           kubernetes_sd_configs:
             - role: endpoints
               namespaces:
@@ -80,7 +80,7 @@ prometheus:
             - source_labels: [__meta_kubernetes_pod_node_name]
               action: replace
               target_label: node
-        - job_name: "kubernetes-pods"
+        - job_name: kubernetes-pods
           kubernetes_sd_configs:
             - role: pod
               namespaces:
@@ -134,6 +134,9 @@ jaeger:
     cassandra: false
   allInOne:
     enabled: true
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "14269"
   storage:
     type: none
   agent:
@@ -142,3 +145,63 @@ jaeger:
     enabled: false
   query:
     enabled: false
+
+opentelemetry-collector:
+  enabled: true
+  mode: deployment
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9090"
+  ports:
+    prometheus:
+      enabled: true
+      containerPort: 9090
+      servicePort: 9090
+      hostPort: 9090
+      protocol: TCP
+    jaeger-compact:
+      enabled: false
+    jaeger-thrift:
+      enabled: false
+    jaeger-grpc:
+      enabled: false
+    zipkin:
+      enabled: false
+  config:
+    receivers:
+      jaeger: null
+      zipkin: null
+      prometheus:
+        config:
+          scrape_configs:
+            - job_name: otel-collector
+              scrape_interval: 10s
+              static_configs:
+                - targets:
+                  - ${env:MY_POD_IP}:8888
+    exporters:
+      otlp/jaeger:
+        endpoint: "{{ .Release.Name }}-jaeger-collector:4317"
+        tls:
+          insecure: true
+      prometheus:
+        endpoint: :9090
+    service:
+      pipelines:
+        metrics:
+          receivers:
+            - otlp
+            - prometheus
+          processors:
+            - memory_limiter
+            - batch
+          exporters:
+            - prometheus
+        traces:
+          receivers:
+            - otlp
+          processors:
+            - memory_limiter
+            - batch
+          exporters:
+            - otlp/jaeger


### PR DESCRIPTION
Adds observability tools to the deployment, including:
- Prometheus for metrics
- Jaeger for tracing
- OpenTelemetry Collector to manage OTEL traces & metrics

No ingresses as these are just being used for testing at the moment