### PR TITLE
Allow CORS from `diamond.ac.uk` subdomains with hyphens

### DIFF
--- a/charts/data-gateway/Chart.yaml
+++ b/charts/data-gateway/Chart.yaml
@@ -3,7 +3,7 @@ name: data-gateway
 description: A GraphQL router deployment forming the Diamond Data Gateway
 type: application
 
-version: 0.6.1
+version: 0.6.2
 
 dependencies:
   - name: prometheus

--- a/charts/data-gateway/values.yaml
+++ b/charts/data-gateway/values.yaml
@@ -253,8 +253,8 @@ router:
               matching: authorization
     cors:
       match_origins:
-        - ^https:\/\/(\w+\.)*diamond\.ac\.uk$
-        - ^https?:\/\/localhost(:\d+)?$
+        - ^https:\/\/([a-zA-Z0-9\-]+\.)*diamond\.ac\.uk\/?
+        - ^https?:\/\/localhost(:\d+)?\/?
     health_check:
       listen: 0.0.0.0:8088
     telemetry:


### PR DESCRIPTION
Replace `\w` (equivalent to `[a-zA-Z0-9]`) with `[a-zA-Z0-9\-]` in `diamond.ac.uk` CORS allow regex