### PR TITLE
Fix secret collision

### DIFF
--- a/charts/apps/Chart.yaml
+++ b/charts/apps/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: graph
 description: ArgoCD Apps used to deploy the Graph
 type: application
-version: 0.2.1
+version: 0.2.2

--- a/charts/apps/templates/nightly.yaml
+++ b/charts/apps/templates/nightly.yaml
@@ -9,7 +9,7 @@ spec:
   project: {{ default .Release.Namespace .Values.project }}
   sources:
     - repoURL: {{ .Values.graph.repoURL }}
-      targetRevision: HEAD
+      targetRevision: {{ .Values.graph.nightlyRevision }}
       path: {{ .Values.graph.path }}
       helm:
         valuesObject:
@@ -47,7 +47,7 @@ spec:
               path: /nightly
     - repoURL: {{ .Values.schema.repoURL }}
       chart: {{ .Values.schema.chart }}
-      targetRevision: "*"
+      targetRevision: {{ .Values.schema.nightlyRevision | quote }}
   destination:
     name: {{ .Values.destination.name }}
     server: {{ .Values.destination.server }}

--- a/charts/apps/templates/stable.yaml
+++ b/charts/apps/templates/stable.yaml
@@ -9,7 +9,7 @@ spec:
   project: {{ default .Release.Namespace .Values.project }}
   sources:
     - repoURL: {{ .Values.graph.repoURL }}
-      targetRevision: {{ .Values.graph.targetRevision }}
+      targetRevision: {{ .Values.graph.stableRevision }}
       path: {{ .Values.graph.path }}
       helm:
         valuesObject:
@@ -38,7 +38,7 @@ spec:
                         trace_context: true
     - repoURL: {{ .Values.schema.repoURL }}
       chart: {{ .Values.schema.chart }}
-      targetRevision: {{ .Values.schema.targetRevision }}
+      targetRevision: {{ .Values.schema.stableRevision | quote }}
   destination:
     name: {{ .Values.destination.name }}
     server: {{ .Values.destination.server }}

--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -7,12 +7,14 @@ monitoring:
 
 graph:
   repoURL: https://github.com/DiamondLightSource/graph-federation
-  targetRevision: HEAD
+  nightlyRevision: HEAD
+  stableRevision: HEAD
   path: charts/graph
 
 schema:
   repoURL: ghcr.io/diamondlightsource/graph-federation-supergraph
-  targetRevision: 0.1.2
+  nightlyRevision: "*"
+  stableRevision: 0.1.2
   chart: supergraph
 
 destination:

--- a/charts/graph/Chart.yaml
+++ b/charts/graph/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: graph
 description: The Diamond data Graph
 type: application
-version: 0.10.1
+version: 0.11.0
 dependencies:
   - name: router
     repository: oci://ghcr.io/apollographql/helm-charts

--- a/charts/graph/templates/oauth2-client-secret.yaml
+++ b/charts/graph/templates/oauth2-client-secret.yaml
@@ -1,15 +1,17 @@
 apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret
 metadata:
-  creationTimestamp: null
-  name: oauth2-client
+  annotations:
+    sealedsecrets.bitnami.com/namespace-wide: "true"
+  name: "{{ .Release.Name }}-oauth2-client"
   namespace: graph
 spec:
-  encryptedData:
-    secret: AgCC4dhJKFpNi4zBFd/29g/YalIXn1GER4wwg9JAaJNJCECQcYGolFrjuA2BXJO3v1KQCvXKr+EuR1JH0sDKaOHbhbJQ/kDeCwqqfK2+oMcf1p5lb/x1fZTnj9HOpNLq3Mjisukn6TA3N1OwTPdLxGLajh9R8Dx4WySKIe/Th4vRth72i3bnIIi3QJnCt5jMKQ6Rls8ENUTZN5uMVliEdt+Cesjo9ZJ435bgJAr8qUK9NBleJ6Qep1Ufx2ptlaqNy+fTpeeusujiegfNzP14jLwh/s0+r5KYXqvIamBsVEsxwx+HReqvCm5uYocKgtgXUU1N/pDCMu7Kz/3TWtKj1HF/0gsUnR8YvQUMmg8p8kDZ/6sfL498q+pIUUoccZkZVQR9hiUPI9n0XXvVA3PDslhpOUMwmEEE05WRKgW1g5c9D9OveV7FExpqyHhFdogpT5QvQ0baY9pjB8EO/6Oqz80gUAw5RNB75KBf744T1gZMDMzIJjIMs6pQlMQXQvLGKGA/JCs910kfMPC1jPtFDJOXnLvQBpPzn4KsVDNmIBFN/ogDbpNVeiptDe9azKKtyBWkycJ3DPIOBoc1AXWaAM199UXr8EOd3ihAH7Rs0Gzsbp2/6FzDef40I0eKDaFI7Po361+pUJkRd8xsHlOEFsBGLw1z6LfPxAA+mKhMV/LI39uiFK/yHmpRlFege2TA/vQa9UNhKF7s9j0VTIJnt06a8HK0EwTS3LO4RLcGDF+8bw==
   template:
+    type: Opaque
     metadata:
-      creationTimestamp: null
-      name: oauth2-client
+      annotations:
+        sealedsecrets.bitnami.com/namespace-wide: "true"
+      name: "{{ .Release.Name }}-oauth2-client"
       namespace: graph
-
+  encryptedData:
+    secret: AgBm/HFZ+1zmTRLltG4bUk4/SCKb5YFlAswVrPChZzUF395p/wgkhpniLMoJAIpcpYNL6antxz/168S185TrVuu2NOZGXaf+4VH8Cn6JzDjaj3P86D9pYKyLePIWoAnIYP1bsyeh6RVg30yluXIGN/4dlhZPnpP5idr3iITYwnk04NwWsdLT9SItit+jxS7Uu7cfF77+WMbvYT5OKcMf1vNqHNcZXfL7gHG0NNPqBfiFqcbcf71I9zPxEK6JiRLIYHQNMVasYd4ml1ZayQxjjNOjOg262DFGcFKLC7NIPWOlpIhtMEQfCl7nH28pufdcIFTDrxvxpyj9EGJRqKnsgeIsI2H68UXXWCcjGcLZX09Hd80ejMwj093/TAnYngaLFIQclpym3Um8XKiLj0/4W+KkHj4CVjnJEou3ikbF3Kn7XewAE8xzyHrbPJEn6cWBC45tpZsO9B3Iy65LKB3RJC/qI6k9FUnZ1EwY/AZU65S1TzE2gzzAeMuXD8OlWyxxH+lsFWrLu1xfm2FtzQc4Zlbk214OHUIE1LSQ6odp/Pbd4T1OeizZU5ot7XvCylBbMECQ7JRT+prFwQIexpwbZ31VREYoFr/j8v5OngD1sT/pk6jCp9TqAGVl59QkPZpiXW31KPn4ojXOr+tvabVkod/pe21zgdtvj0dRyS9MIFexia0HIMPq0tnQPaE5yJY2UHezZA/1fVToC3PQytG0Zqj/JrfZyzhgOMAqDPMmUvF8bA==

--- a/charts/graph/values.yaml
+++ b/charts/graph/values.yaml
@@ -106,7 +106,7 @@ oauth2-proxy:
   extraVolumes:
     - name: client-secret
       secret:
-        secretName: oauth2-client
+        secretName: "{{ .Release.Name }}-oauth2-client"
         items:
           - key: secret
             path: client-secret


### PR DESCRIPTION
Prefixes the oauth2 client secret name with the helm `.Release.Name` to avoid name collision between the stable and nightly instance. Blocked by templating of `extraVolumes` in the `oauth2-proxy` helm chart - [PR to add](https://github.com/oauth2-proxy/manifests/pull/224)