### PR TITLE
Move nightly graph to separate domain

### DIFF
--- a/charts/apps/Chart.yaml
+++ b/charts/apps/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: graph
 description: ArgoCD Apps used to deploy the Graph
 type: application
-version: 0.2.2
+version: 0.2.3

--- a/charts/apps/templates/nightly.yaml
+++ b/charts/apps/templates/nightly.yaml
@@ -16,12 +16,6 @@ spec:
           router:
             router:
               configuration:
-                homepage:
-                  enabled: true
-                sandbox:
-                  enabled: false
-                supergraph:
-                  path: /nightly
                 telemetry:
                   exporters:
                     metrics:
@@ -44,7 +38,24 @@ spec:
                         trace_context: true
           oauth2-proxy:
             ingress:
-              path: /nightly
+              hostname: graph-nightly.diamond.ac.uk
+              hosts:
+                - graph-nightly.diamond.ac.uk
+            alphaConfig:
+              configData:
+                providers:
+                  - provider: oidc
+                    scope: "openid profile email fedid"
+                    clientId: graph-nightly
+                    clientSecretFile: /etc/alpha/client-secret
+                    id: authn
+                    oidcConfig:
+                      issuerURL: https://authn.diamond.ac.uk/realms/dls
+                      insecureAllowUnverifiedEmail: true
+                      audienceClaims:
+                        - aud
+                      emailClaim: email
+                      userIDClaim: email
     - repoURL: {{ .Values.schema.repoURL }}
       chart: {{ .Values.schema.chart }}
       targetRevision: {{ .Values.schema.nightlyRevision | quote }}

--- a/charts/graph/Chart.yaml
+++ b/charts/graph/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: graph
 description: The Diamond data Graph
 type: application
-version: 0.11.1
+version: 0.12.0
 dependencies:
   - name: router
     repository: oci://ghcr.io/apollographql/helm-charts

--- a/charts/graph/templates/oauth2-client-secret.yaml
+++ b/charts/graph/templates/oauth2-client-secret.yaml
@@ -1,7 +1,10 @@
+{{ $clientId := (index (index .Values "oauth2-proxy").alphaConfig.configData.providers 0).clientId }}
+{{- if eq $clientId "graph" }}
 apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret
 metadata:
   annotations:
+    authn.diamond.ac.uk/client-id: {{ $clientId }}
     sealedsecrets.bitnami.com/namespace-wide: "true"
   name: "{{ .Release.Name }}-oauth2-client"
   namespace: graph
@@ -10,8 +13,29 @@ spec:
     type: Opaque
     metadata:
       annotations:
+        authn.diamond.ac.uk/client-id: {{ $clientId }}
         sealedsecrets.bitnami.com/namespace-wide: "true"
       name: "{{ .Release.Name }}-oauth2-client"
       namespace: graph
   encryptedData:
     secret: AgBm/HFZ+1zmTRLltG4bUk4/SCKb5YFlAswVrPChZzUF395p/wgkhpniLMoJAIpcpYNL6antxz/168S185TrVuu2NOZGXaf+4VH8Cn6JzDjaj3P86D9pYKyLePIWoAnIYP1bsyeh6RVg30yluXIGN/4dlhZPnpP5idr3iITYwnk04NwWsdLT9SItit+jxS7Uu7cfF77+WMbvYT5OKcMf1vNqHNcZXfL7gHG0NNPqBfiFqcbcf71I9zPxEK6JiRLIYHQNMVasYd4ml1ZayQxjjNOjOg262DFGcFKLC7NIPWOlpIhtMEQfCl7nH28pufdcIFTDrxvxpyj9EGJRqKnsgeIsI2H68UXXWCcjGcLZX09Hd80ejMwj093/TAnYngaLFIQclpym3Um8XKiLj0/4W+KkHj4CVjnJEou3ikbF3Kn7XewAE8xzyHrbPJEn6cWBC45tpZsO9B3Iy65LKB3RJC/qI6k9FUnZ1EwY/AZU65S1TzE2gzzAeMuXD8OlWyxxH+lsFWrLu1xfm2FtzQc4Zlbk214OHUIE1LSQ6odp/Pbd4T1OeizZU5ot7XvCylBbMECQ7JRT+prFwQIexpwbZ31VREYoFr/j8v5OngD1sT/pk6jCp9TqAGVl59QkPZpiXW31KPn4ojXOr+tvabVkod/pe21zgdtvj0dRyS9MIFexia0HIMPq0tnQPaE5yJY2UHezZA/1fVToC3PQytG0Zqj/JrfZyzhgOMAqDPMmUvF8bA==
+{{- else if eq $clientId "graph-nightly" -}}
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  annotations:
+    authn.diamond.ac.uk/client-id: {{ $clientId }}
+    sealedsecrets.bitnami.com/namespace-wide: "true"
+  name: "{{ .Release.Name }}-oauth2-client"
+  namespace: graph
+spec:
+  template:
+    metadata:
+      annotations:
+        authn.diamond.ac.uk/client-id: {{ $clientId }}
+        sealedsecrets.bitnami.com/namespace-wide: "true"
+      name: "{{ .Release.Name }}-oauth2-client"
+      namespace: graph
+  encryptedData:
+    secret: AgAyjcgt/dAA2iEgXOGB2YFuGvDVD386BaWPJt3kipSqgs2pd3qB7x9ij8/eeQU6sPCwRRuBb0+RvbkIjJ2STNxa6v0pDd6fyejT3Zl2CJb1VGVgUWp2r4RunFoCtOFNKD8AnTGbTODO/dqmpVBRz/pcpnZyq0XkGBLiRB1/Qgbh69RGW5kXb1bL32/0rMKc1WKVNnffBwb9FE6rWAojUxV11UZQxw2d7nCjcQObz7XxI9VSQ+USv455mn4VLPWYSwt2P/wFIDnVaNBZ+jw2Ji87hOML+Or7QyUE2gtW28/Qf7bL4WJhk3HxaaJwFomziLol2hXq3mphYmo39IfxOUPCMfc8CY3hKoBwSTlGQ2MQnrYLbs1Klc18AWBd6dPSDGDN1uV/Fn2j6VxVgaP+BVKAH7DnhKlAxJhowY28thi1cud7CXVgNdcEoKQXcOwsNkFphH+9STtL0r+cYQK+SW02sGxL+pCXXMb+0TCCMsc5bhok8qsQIO7GNb65VQzilisgmXCYQ1fJjBTBotcwm14nqvChmTH6T+QVL3dtxOGCDX8FCHaSPIk26tvpU7ePeu9zoDUNNnxe1u9YAvxbFR2aaVj2735TwcdK/Sc+rOzr6jAltU21OwUOqd1ND883Sd3R95Pk+OniBz1UPi+2ykk/Tg6jkfu408bDOE9bIX6t1+AQRXVpIiAa04ysNSqYkzgrhyEw03t8BHRtrAxJRG6Wq2evdRz1KneID1ShajDd3w==
+{{- end }}

--- a/charts/graph/values.yaml
+++ b/charts/graph/values.yaml
@@ -75,12 +75,7 @@ oauth2-proxy:
       ]
   alphaConfig:
     enabled: true
-    configFile: |
-      upstreamConfig:
-        upstreams:
-          - id: router
-            path: /
-            uri: http://{{ .Release.Name }}-router:80
+    configData:
       injectRequestHeaders:
         - name: Authorization
           values:
@@ -104,6 +99,12 @@ oauth2-proxy:
               - aud
             emailClaim: email
             userIDClaim: email
+    configFile: |
+      upstreamConfig:
+        upstreams:
+          - id: router
+            path: /
+            uri: http://{{ .Release.Name }}-router:80
   extraVolumes:
     - name: client-secret
       secret:


### PR DESCRIPTION
It's just a whole lot easier than making `/nightly` work. Should move to `nightly.graph.diamond.ac.uk` once we have certmanager available