### PR TITLE
Lint commits with `commitlint`

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "@commitlint/config-conventional"
+  ]
+}

--- a/.github/workflows/_lint_commits.yaml
+++ b/.github/workflows/_lint_commits.yaml
@@ -1,0 +1,21 @@
+name: Lint Commits
+
+on:
+  workflow_call:
+
+jobs:
+  lint_commits:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Lint Commits
+        uses: wagoid/commitlint-github-action@v6.1.2
+        with:
+          failOnWarnings: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,11 @@ on:
   pull_request:
 
 jobs:
+  lint_commits:
+    # Deduplicate jobs from pull requests and branch pushes within the same repo.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
+    uses: ./.github/workflows/_lint_commits.yaml
+
   helm_lint:
     # Deduplicate jobs from pull requests and branch pushes within the same repo.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository


### PR DESCRIPTION
Depends on #63 

Ensures that all commits conform to [conventional commits](https://www.conventionalcommits.org/) - setting us up nicely to use [`release-please`](https://github.com/googleapis/release-please)