### PR TITLE
Publish supergraph chart every update

### DIFF
--- a/.github/workflows/_supergraph_publish.yaml
+++ b/.github/workflows/_supergraph_publish.yaml
@@ -2,11 +2,6 @@ name: Publish Supergraph Schema
 
 on:
   workflow_call:
-    inputs:
-      publish:
-        type: boolean
-        required: true
-        default: false
 
 jobs:
   publish:
@@ -29,16 +24,30 @@ jobs:
           name: supergraph.graphql
           path: charts/supergraph
 
-      - name: Package Chart
+      - name: Generate Chart Version
+        id: version
         run: |
-          LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
-          helm package charts/supergraph --version $LATEST_TAG
+          if LATEST_TAG=$(git describe --tags --abbrev=0); then
+            COMMITS_SINCE=$(git rev-list $LATEST_TAG..HEAD --count)
+          else
+            LATEST_TAG="0.0.0"
+            COMMITS_SINCE=$(git rev-list HEAD --count)
+          fi
+          VERSION=$([ "$COMMITS_SINCE" == 0 ] && echo "$LATEST_TAG" || echo "$LATEST_TAG+$COMMITS_SINCE" )
+          echo "Using Version: $VERSION"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Package Chart
+        run: helm package charts/supergraph --version "${{ steps.version.outputs.version }}"
 
       - name: Generate Image Name
-        run: echo IMAGE_REPOSITORY=oci://ghcr.io/$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]' | tr '[_]' '[\-]') >> $GITHUB_ENV
+        run: |
+          IMAGE_REPOSITORY="oci://ghcr.io/$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]' | tr '[_]' '[\-]')"
+          echo "Using Image Name: $IMAGE_REPOSITORY"
+          echo "IMAGE_REPOSITORY=$IMAGE_REPOSITORY" >> $GITHUB_ENV
 
       - name: Log in to GitHub Docker Registry
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push' && ( startsWith(github.ref, 'refs/tags') || startsWith(github.ref, 'refs/heads/main') )
         uses: docker/login-action@v3.3.0
         with:
           registry: ghcr.io
@@ -46,5 +55,5 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish Chart
-        if: ${{ inputs.publish }}
+        if: github.event_name == 'push' && ( startsWith(github.ref, 'refs/tags') || startsWith(github.ref, 'refs/heads/main') )
         run: helm push $(ls supergraph-*.tgz) ${{ env.IMAGE_REPOSITORY }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,8 +30,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-    with:
-      publish: ${{ needs.release_please.outputs.supergraph-chart-released == 'true' }}
 
   compose_workflow:
     # Deduplicate jobs from pull requests and branch pushes within the same repo.


### PR DESCRIPTION
As discussed, uses the semver 2.0 build suffix to denote the number of commits since the last tag - this is published with every commit.

We should think about if we need to publish on every commit or just the ones which touch relevant files and how we de-duplicate / clean these up in the near future