### PR TITLE
Use `ci` prefix for `dependabot` commits

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -16,3 +16,5 @@ updates:
         update-types:
           - minor
           - patch
+    commit-message:
+      prefix: ci


### PR DESCRIPTION
Allows `dependabot` to pass the conventional commits lint