### PR TITLE
Fix `markdownlint` CI

### DIFF
--- a/.github/workflows/_docs.yaml
+++ b/.github/workflows/_docs.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Lint with markdownlint-cli2
         run: >
           markdownlint-cli2
-          **/*.{md,markdown}
+          "**/*.{md,markdown}"
 
   build:
     needs: lint

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,11 @@
+{
+  "config": {
+    "MD013": false, // Disabled because long lines are useful
+    "MD046": false // Disabled because of conflicts with admonitions
+  },
+  "markdownItPlugins": [
+    [
+      "markdown-it-admon"
+    ]
+  ]
+}

--- a/docs/how-tos/add-subgraph-schema.md
+++ b/docs/how-tos/add-subgraph-schema.md
@@ -85,6 +85,7 @@ As part of our continuous integration process on GitHub, we can use the [`diamon
 
 To update the deployed supergraph schema, we should create a Pull Request to the [`graph-federation` repository](https://github.com/DiamondLightSource/graph-federation/) with the desired subgraph schema and relevant configuration changes.
 
+<!-- markdownlint-disable-next-line MD024 -->
 ### GitHub CI
 
 A [GitHub App](https://docs.github.com/en/apps/creating-github-apps/about-creating-github-apps/about-creating-github-apps) can be created in order to act as a bot account capable of pushing to branches and creating Pull Requests from the GitHub actions of another repository. The [`diamondlightsource/graph-federation/workflows/update`] action can be used to perform the necessary schema composition, branch update, and pull request generation.

--- a/docs/how-tos/python_consume.md
+++ b/docs/how-tos/python_consume.md
@@ -1,10 +1,10 @@
 # Python Consumer
 
-## Preface 
+## Preface
 
-This guide will explain how to fetch data from a GraphQL endpoint and map the response to a 
-Pydantic model. 
-We will cover: 
+This guide will explain how to fetch data from a GraphQL endpoint and map the response to a
+Pydantic model.
+We will cover:
 
 - Defining a Pydantic model in [Define the Pydantic Model](#define-the-pydantic-model)
 - Fetching the data from GraphQL API in [Fetch Data from GraphQL API](#fetch-data-from-graphql-api)
@@ -18,7 +18,7 @@ We will cover:
       - [`sgqlc`](https://github.com/profusion/sgqlc) for typed code generation
       - [`ariadne-codegen`](https://github.com/mirumee/ariadne-codegen) for `pydantic` compatible code generation
 
-## Dependencies 
+## Dependencies
 
 This guide will utilize the following dependencies:
 
@@ -27,7 +27,7 @@ This guide will utilize the following dependencies:
 
 ## Define the Pydantic Model
 
-??? tip "More about Pydantic" 
+??? tip "More about Pydantic"
 
     Pydantic is a data validation and parsing library in Python. It provides a efficient way to 
     validate and parse data into Python objects. We can use pydantic models to define the structure and type
@@ -35,8 +35,8 @@ This guide will utilize the following dependencies:
     the defined type annotations. If the data does not match the expected types, Pydantic raises errors 
     ensuring the integrity of the data. 
 
-To create a Pydantic model, we define a class with Pydantic's `BaseModel` class as the base class. 
-We can define a `Person` class with the attributes we intend to fetch from the endpoint. 
+To create a Pydantic model, we define a class with Pydantic's `BaseModel` class as the base class.
+We can define a `Person` class with the attributes we intend to fetch from the endpoint.
 
 !!! example "Define Pydantic Model"
 
@@ -62,7 +62,7 @@ We can define a `Person` class with the attributes we intend to fetch from the e
 ## Fetch Data From GraphQL API
 
 To fetch data from a GraphQL API, we use the `requests` library to send a POST request with a GraphQL query.
-We specify the GraphQL query as a string. 
+We specify the GraphQL query as a string.
 
 !!! example "Fetch Data"
 
@@ -83,6 +83,7 @@ We specify the GraphQL query as a string.
     response = requests.post(url, json={'query': graphql_query})
 
     ```
+
 ## Map Response to Pydantic Model
 
 We can now map the json response we got from the endpoint to a Pydantic model by  using Pydantics `model_validate_json()` method
@@ -100,7 +101,7 @@ We can now map the json response we got from the endpoint to a Pydantic model by
 
     ```
 
-If the [Python graphQL service](https://diamondlightsource.github.io/graph-federation/how-tos/python_service/) is running, `person` 
-should output: 
+If the [Python graphQL service](https://diamondlightsource.github.io/graph-federation/how-tos/python_service/) is running, `person`
+should output:
 
 `id=1 first_name='foo' last_name='bar'`

--- a/docs/how-tos/python_service.md
+++ b/docs/how-tos/python_service.md
@@ -170,7 +170,7 @@ This will generate a string in the [GraphQL Schema Language](https://graphql.org
     You will likely want to create a program entrypoint or CLI option which writes the schema to a file.
 
 !!! example "Schema Generation"
-    
+
     ```python
     from strawberry.federation import Schema
     from strawberry.printer import print_schema

--- a/docs/how-tos/rust_service.md
+++ b/docs/how-tos/rust_service.md
@@ -15,7 +15,7 @@ We will cover:
 This guide will utilize the following dependencies:
 
 - `axum` as the HTTP server
-- `async-graphql` as graphql server library 
+- `async-graphql` as graphql server library
 - `async-graphql-axum` for GraphQL request handling
 - `tokio` as runtime for writing asynchronous rust program with macros and rt-multi-thread feature enabled
 
@@ -23,7 +23,6 @@ This guide will utilize the following dependencies:
 
     `async-graphql` provides a high-performance server-side implementation of the GraphQL specification.
     It is designed to leverage Rust's asynchronous programming capabilities (using Tokio or async-std) to handle GraphQL queries efficiently and concurrently.
-
 
 ```toml
 [dependencies]
@@ -77,7 +76,7 @@ To handle GraphQL requests, we start by creating a server with a placeholder Gra
 data and converts it into a form that can be processed by async-graphql.
 
 `GraphQLResponse` wraps the results of executing a GraphQL query. It ensures
-that the response is correctly formatted as a valid HTTP response that Axum can 
+that the response is correctly formatted as a valid HTTP response that Axum can
 send back to the client.
 
 ## Defining Objects
@@ -103,6 +102,7 @@ struct Person {
     preferred_name: Option<String>,
 }
 ```
+
 We can write a resolver for the `Person`. A resolver function resolvers the values for all the fields a GraphQL object.
 
 !!! example "Defind Object and a Resolver"
@@ -124,7 +124,7 @@ We can write a resolver for the `Person`. A resolver function resolvers the valu
     }
     ```
 We can also add additional fields to the Objects that are not initially defined in the struct using `Impl`. To add a new field
-`name` to the `Person` Object we implement a `name` function. 
+`name` to the `Person` Object we implement a `name` function.
 
 !!! example "Add name field to Person Object"
 
@@ -139,7 +139,7 @@ We can also add additional fields to the Objects that are not initially defined 
     }
     ```
 
-Putting everything together, we should be able to run the follwing code, 
+Putting everything together, we should be able to run the follwing code,
 
 !!! example "Simple GraphQL service to provide a Person information"
 
@@ -194,6 +194,7 @@ Putting everything together, we should be able to run the follwing code,
     }
     ```
 When we send request to the endpoint `curl -X POST -H "Content-Type: application/json" -d '{"query":"{ person {id, firstName, lastName, preferredName} }"}' http://127.0.0.1:8000/graphql` we should get the following response
+
 ```json
 {
     "data":{
@@ -212,7 +213,7 @@ When we send request to the endpoint `curl -X POST -H "Content-Type: application
 Most of the fields of a GraphQL object directly return the value of the field,
 but sometimes the the fields are calculated or resolved by a different resolver.
 In such cases, we can use the `ComplexObject` macro to write a user defined resolver.
-This can be useful when we want to resolve related Objects. 
+This can be useful when we want to resolve related Objects.
 We need to use `complex` macro on `Person` struct for the `ComplexObject` macro to take effect.
 
 !!! example "Related Objects"
@@ -244,9 +245,10 @@ We need to use `complex` macro on `Person` struct for the `ComplexObject` macro 
     }
     ```
 
-Now the `Person` object should have a `pet` field that resolvers a `Pet` object. When we send request to the endpoint, 
+Now the `Person` object should have a `pet` field that resolvers a `Pet` object. When we send request to the endpoint,
 `curl -X POST -H "Content-Type: application/json" -d '{"query":"{ person {id, pet {id}} }"}' http://127.0.0.1:8000/graphql`
 we should get the following response
+
 ```json
 {
     "data":{
@@ -259,6 +261,7 @@ we should get the following response
 ```
 
 ## Federated
+
 !!! info
 
     Refer to [Async-graphql Book Apollo Federation](https://async-graphql.github.io/async-graphql/en/apollo_federation.html) for a full explanation on federation using rust. 
@@ -273,7 +276,7 @@ To enable federation support we can the `schema.enable_federation()` method.
         .finish();
     ```
 
-We can extends the fields of an Object from another service/subgraph using Entities and @key. 
+We can extends the fields of an Object from another service/subgraph using Entities and @key.
 
 !!! info
 
@@ -341,10 +344,11 @@ We need to use `complex` macro on `Pet` struct for the `ComplexObject` macro to 
         }
     }
     ```
+
 ## Schema Generation
 
 We can generate schema using `schema.sdl_with_options()` method. To enable federation declaratives we should
-pass `SDLExportOptions::new().federation()` as an argument to the method. 
+pass `SDLExportOptions::new().federation()` as an argument to the method.
 
 !!! example "Generate Schema with federation declaratives"
 

--- a/docs/references/terminology.md
+++ b/docs/references/terminology.md
@@ -1,15 +1,14 @@
 # Terminology
 
-### Schema
+## Schema
 
 A GraphQL schema is an artifact describing the API provided by a given GraphQL endpoint.
 This is likely to contain a set of [Queries](https://spec.graphql.org/October2021/#sec-Query), [Mutations](https://spec.graphql.org/October2021/#sec-Mutation) and [Subscriptions](https://spec.graphql.org/October2021/#sec-Subscription), and a description of the [Objects](https://spec.graphql.org/October2021/#sec-Objects) which they return.
 
+## Subgraph Schema
 
-### Subgraph Schema
-A Subgraph is the [Schema](#schema) of an individual service. These may be stitched together to form a [Supergraph](#supergraph).
+A Subgraph is the [Schema](#schema) of an individual service. These may be stitched together to form a [Supergraph Schema](#supergraph-schema).
 
-### Supergraph Schema
+## Supergraph Schema
 
-A Supergraph is simply a GraphQL [Schema](#schema) which has been stitched together from various [Subgraphs](#subgraph).
-
+A Supergraph is simply a GraphQL [Schema](#schema) which has been stitched together from various [Subgraph Schemas](#subgraph-schema).


### PR DESCRIPTION
Having the glob unquoted meant that it was only including the two markdown files at the root of the repo. Have fixed most lints and allowed long lines and varying code block styles