### PR TITLE
Allow long commit lines

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,5 +1,11 @@
 {
   "extends": [
     "@commitlint/config-conventional"
-  ]
+  ],
+  "rules": {
+    "body-max-line-length": [
+      0,
+      "always"
+    ]
+  }
 }

--- a/.github/workflows/_lint_commits.yaml
+++ b/.github/workflows/_lint_commits.yaml
@@ -18,4 +18,5 @@ jobs:
       - name: Lint Commits
         uses: wagoid/commitlint-github-action@v6.1.2
         with:
+          configFile: .commitlintrc.json
           failOnWarnings: true


### PR DESCRIPTION
Eases restrictions on commit line lengths to enable use of `dependabot`, which cannot be configured to format commits