### PR TITLE
ci: unpin broken node version for docs lint

### DIFF
--- a/.github/workflows/_docs.yaml
+++ b/.github/workflows/_docs.yaml
@@ -17,8 +17,6 @@ jobs:
 
       - name: Setup Node
         uses: actions/setup-node@v4.2.0
-        with:
-          node-version: 18
 
       - name: Install Yarn dependencies
         uses: borales/actions-yarn@v5.0.0


### PR DESCRIPTION
The lint dependencies no longer support node18, causing the failing CI in #99,
Unpinning this should use the node version described by the action