### PR TITLE
chore(ci): pin graphql to 16.14.2 in generate action

### DIFF
--- a/.github/workflows/_supergraph_generate.yaml
+++ b/.github/workflows/_supergraph_generate.yaml
@@ -35,7 +35,7 @@ jobs:
           path: router-execution-config.json
 
       - name: Install Supergraph Schema Composition dependencies
-        run: npm install @wundergraph/composition graphql js-yaml
+        run: npm install @wundergraph/composition graphql@16.14.2 js-yaml
 
       - name: Generate Supergraph Schema
         run: |


### PR DESCRIPTION
The _supergraph_generate action [seems to be failing](https://github.com/DiamondLightSource/graph-federation/actions/runs/27744670634/job/82079940989) as of the release of [graqhql.js 17.0.0](https://npmx.dev/package/graphql/v/17.0.0) - I haven't looked into an actual fix, but this seemed marginally more helpful than opening an issue