### PR TITLE
fix(action): do not persist credentials

### DIFF
--- a/.github/workflows/_actions.yaml
+++ b/.github/workflows/_actions.yaml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Create Test Subgraph schema
         run: >
@@ -42,7 +44,6 @@ jobs:
           supergraph-artifact: compose-supergraph-without-app
           supergraph-filename: supergraph.graphql
           publish: false
-          persist-credentials: false
 
       - name: Check Supergraph with App
         uses: ./

--- a/.github/workflows/_actions.yaml
+++ b/.github/workflows/_actions.yaml
@@ -42,6 +42,7 @@ jobs:
           supergraph-artifact: compose-supergraph-without-app
           supergraph-filename: supergraph.graphql
           publish: false
+          persist-credentials: false
 
       - name: Check Supergraph with App
         uses: ./

--- a/action.yaml
+++ b/action.yaml
@@ -84,7 +84,7 @@ runs:
         repositories: graph-federation
 
     - name: Checkout Graph Federation source
-      uses: actions/checkout@v4.2.2
+      uses: actions/checkout@v6
       with:
         repository: DiamondLightSource/graph-federation
         token: ${{ steps.app-token.outputs.token || github.token }}

--- a/docs/how-tos/add-subgraph-schema.md
+++ b/docs/how-tos/add-subgraph-schema.md
@@ -25,7 +25,7 @@ It is useful to upload the schema as an artifact to allow download both in futur
         runs-on: ubuntu-latest
         steps:
           - name: Checkout source
-            uses: actions/checkout@v4.1.7
+            uses: actions/checkout@v6
 
           - name: Setup Python
             uses: actions/setup-python@v5.2.0


### PR DESCRIPTION
Credentials now persist in actions/checkout@v6, [causing CI to fail with an Authorization error](https://github.com/actions/checkout/issues/485)

Sets `persist-credentials: false` so Authorization headers are not duplicated.