### PR TITLE
fix: set workflows subscription-protocol to ws

### DIFF
--- a/supergraph-config.yaml
+++ b/supergraph-config.yaml
@@ -4,7 +4,7 @@ subgraphs:
     routing_url: https://workflows.diamond.ac.uk/graphql
     subscription:
       url: wss://workflows.diamond.ac.uk/graphql/ws
-      protocol: graphql-ws
+      protocol: ws
     schema:
       file: schema/workflows.graphql
   - name: schemas


### PR DESCRIPTION
Subscription protocol for websockets should just be ws and this supports graphql-ws. See https://cosmo-docs.wundergraph.com/router/subscriptions/router-configuration-for-subscriptions